### PR TITLE
Adding CRC32C

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ after_success:
 env:
   global:
     - TRAVIS_CARGO_NIGHTLY_FEATURE=""
+    - RUSTFLAGS="-C target-feature=+sse4.2"
 
 dist: trusty
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,9 @@ authors = ["Chao Sun <sunchao@apache.org>"]
 
 [dependencies]
 crossbeam = "0.3.0" # for scoped threads
+x86intrin = "0.4.3" # for HW features such as SSE 4.2
+lazy_static = "0.2" # for initializing static vars
+byteorder = "1"     # for reinterpreting bytes
+
+[dev-dependencies]
+rand = "0.3"

--- a/benches/crc32c.rs
+++ b/benches/crc32c.rs
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![feature(cfg_target_feature)]
+#![feature(test)]
+extern crate test;
+extern crate leveldb;
+extern crate rand;
+
+macro_rules! bench_base {
+  ($bench_name:ident, $fname:ident, $block_size:expr) => {
+    #[bench]
+    fn $bench_name(b: &mut ::test::Bencher) {
+      let block_data = vec!['x' as u8; $block_size];
+      b.bytes = block_data.len() as u64;
+      b.iter(|| {
+        ::leveldb::util::crc32c::$fname(0, &block_data);
+      })
+    }
+  }
+}
+
+macro_rules! bench_sw {
+  ($bench_name:ident, $block_size:expr) => {
+    bench_base!($bench_name, extend_sw, $block_size);
+  }
+}
+
+macro_rules! bench_hw {
+  ($bench_name:ident, $block_size:expr) => {
+    #[cfg(target_feature="sse4.2")]
+    bench_base!($bench_name, extend_hw, $block_size);
+  }
+}
+
+bench_sw!(sw_00000256, 00000256);
+bench_sw!(sw_00004096, 00004096);
+bench_sw!(sw_00060056, 00060056);
+bench_sw!(sw_01048576, 01048576);
+bench_sw!(sw_16777216, 16777216);
+
+bench_hw!(hw_00000256, 00000256);
+bench_hw!(hw_00004096, 00004096);
+bench_hw!(hw_00060056, 00060056);
+bench_hw!(hw_01048576, 01048576);
+bench_hw!(hw_16777216, 16777216);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,14 @@
 #![feature(compiler_fences)]
 #![feature(rustc_private)]
 #![feature(try_from)]
+#![feature(cfg_target_feature)]
 
 extern crate arena;
 extern crate crossbeam;
+extern crate x86intrin;
+#[macro_use]
+extern crate lazy_static;
+extern crate byteorder;
 
 pub mod util;
 #[macro_use]

--- a/src/util/crc32c.rs
+++ b/src/util/crc32c.rs
@@ -1,0 +1,174 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use byteorder::{ByteOrder, LittleEndian as LE};
+#[cfg(target_feature="sse4.2")]
+use x86intrin::sse42;
+
+const CRC32_XOR: u32 = 0xffffffff;
+const CASTAGNOLI_POLY: u32 = 0x82f63b78;
+
+lazy_static! {
+  static ref TABLE16: [[u32; 256]; 16] = {
+    let mut tab = [[0; 256]; 16];
+    tab[0] = make_table(CASTAGNOLI_POLY);
+    for i in 0..256 {
+      let mut crc = tab[0][i];
+      for j in 1..16 {
+        crc = (crc >> 8) ^ tab[0][crc as u8 as usize];
+        tab[j][i] = crc;
+      }
+    }
+    tab
+  };
+}
+
+pub fn value(data: &[u8]) -> u32 {
+  extend(0, data)
+}
+
+pub fn extend(crc: u32, data: &[u8]) -> u32 {
+  #[cfg(target_feature="sse4.2")] {
+    extend_hw(crc, data)
+  }
+  #[cfg(not(target_feature="sse4.2"))] {
+    extend_sw(crc, data)
+  }
+}
+
+pub fn extend_sw(crc: u32, mut data: &[u8]) -> u32 {
+  let tab8 = &*TABLE16;
+  let mut l: u32 = crc ^ CRC32_XOR;
+  while data.len() >= 8 {
+    l ^= LE::read_u32(&data[0..4]);
+    l = tab8[0][data[7] as usize]
+      ^ tab8[1][data[6] as usize]
+      ^ tab8[2][data[5] as usize]
+      ^ tab8[3][data[4] as usize]
+      ^ tab8[4][(l >> 24) as u8 as usize]
+      ^ tab8[5][(l >> 16) as u8 as usize]
+      ^ tab8[6][(l >> 8 ) as u8 as usize]
+      ^ tab8[7][(l      ) as u8 as usize];
+    data = &data[8..];
+  }
+  for &b in data {
+    l = tab8[0][((l as u8) ^ b) as usize] ^ (l >> 8);
+  }
+  l ^ CRC32_XOR
+}
+
+#[cfg(target_feature="sse4.2")]
+pub fn extend_hw(crc: u32, data: &[u8]) -> u32 {
+  let mut l: u32 = crc ^ CRC32_XOR;
+  let size = data.len();
+  let mut offset = 0;
+  if size > 16 {
+    let start_offset = align_offset(8, data);
+    while offset != start_offset {
+      l = sse42::mm_crc32_u8(l, data[offset]);
+      offset += 1;
+    }
+    while size - offset >= 8 {
+      l = sse42::mm_crc32_u64(l as u64, LE::read_u64(&data[offset..])) as u32;
+      offset += 8;
+    }
+    while size - offset >= 4 {
+      l = sse42::mm_crc32_u32(l, LE::read_u32(&data[offset..]));
+      offset += 4;
+    }
+  }
+
+  while offset != size {
+    l = sse42::mm_crc32_u8(l, data[offset]);
+    offset += 1;
+  }
+  l ^ CRC32_XOR
+}
+
+#[cfg(target_feature="sse4.2")]
+fn align_offset(align: usize, data: &[u8]) -> usize {
+  assert!(align & (align - 1) == 0);
+  let ptr = data.as_ptr() as usize;
+  ((ptr + (align - 1)) & !(align - 1)) - ptr
+}
+
+fn make_table(poly: u32) -> [u32; 256] {
+  let mut tab = [0; 256];
+  for i in 0u32..256u32 {
+    let mut crc = i;
+    for _ in 0..8 {
+      if crc & 1 == 1 {
+        crc = (crc >> 1) ^ poly;
+      } else {
+        crc >>= 1;
+      }
+    }
+    tab[i as usize] = crc;
+  }
+  tab
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  pub fn test_standard_results() {
+    let buf: Vec<u8> = vec![0; 32];
+    assert_eq!(value(&buf), 0x8a9136aa);
+
+    let mut buf: Vec<u8> = vec![0xff; 32];
+    assert_eq!(value(&buf), 0x62a8ab43);
+
+    for i in 0..32 {
+      buf[i] = i as u8;
+    }
+    assert_eq!(value(&buf), 0x46dd794e);
+
+    for i in 0..32 {
+      buf[i] = (31 - i) as u8;
+    }
+    assert_eq!(value(&buf), 0x113fdb5c);
+
+    let data = [
+      0x01, 0xc0, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x14, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x04, 0x00,
+      0x00, 0x00, 0x00, 0x14,
+      0x00, 0x00, 0x00, 0x18,
+      0x28, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x02, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+    ];
+    assert_eq!(value(&data), 0xd9963a56);
+  }
+
+  #[test]
+  pub fn test_values() {
+    assert_ne!(value("a".as_bytes()), value("foo".as_bytes()));
+  }
+
+  #[test]
+  pub fn test_extend() {
+    assert_eq!(value("hello world".as_bytes()),
+      extend(value("hello ".as_bytes()), "world".as_bytes()));
+  }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -21,3 +21,4 @@ pub mod coding;
 pub mod hash;
 pub mod random;
 pub mod bit;
+pub mod crc32c;


### PR DESCRIPTION
This adds two implementations for CRC32C: one using the SSE4.2, and the
other using software-based portable implementation.

Fixes #1