### PR TITLE
Fix illegal pointer reference in LookupKey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![feature(box_syntax)]
 #![feature(compiler_fences)]
 #![feature(rustc_private)]
 #![feature(try_from)]


### PR DESCRIPTION
In the LookupKey struct we currently allocate fixed length array on
stack if the key size is small enough, and then store the pointer to the
array. This, however, will fail since later on the array will be moved
to an new address, but the pointer is still referring to the old memory
location!

It seems dangerous to operate on the pointer in this case. This commit
changes LookupKey to allocate the array on heap in all cases. We shall
see how the performance impact of this is, and come back later if
necessary.